### PR TITLE
Accessの実装（修正）

### DIFF
--- a/src/ejs/access/index.ejs
+++ b/src/ejs/access/index.ejs
@@ -12,6 +12,9 @@
 </html>
 
 <body>
+
+  <%- include('../_includes/_header') %>
+
   <main>
     <article class="p-access">
       <div class="p-access__mainvisual"></div>
@@ -47,5 +50,8 @@
 
     </article>
   </main>
-  </body>
+
+  <%- include('../_includes/_footer.ejs') %>
+</body>
+
 </html>


### PR DESCRIPTION
<%- include('../_includes/_header') %>
<%- include('../_includes/_footer.ejs') %>

ejsから上記を削除したことにより、ヘッダー、フッターが表示されていない問題がありましたので、修正しました。