### PR TITLE
Accessページを開いた際のヘッダー、フッターが表示されない問題を解消

### DIFF
--- a/src/ejs/access/index.ejs
+++ b/src/ejs/access/index.ejs
@@ -12,6 +12,9 @@
 </html>
 
 <body>
+
+  <%- include('../_includes/_header') %>
+
   <main>
     <article class="p-access">
       <div class="p-access__mainvisual"></div>
@@ -47,5 +50,9 @@
 
     </article>
   </main>
-  </body>
+
+  <%- include('../_includes/_footer.ejs') %>
+
+</body>
+
 </html>


### PR DESCRIPTION
<%- include('../_includes/_header') %>
<%- include('../_includes/_footer.ejs') %>

・上記2点を追加